### PR TITLE
Soft Deprecation without deprecation made it usefull

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # create-path
-runs npx mkdirp \<path\> when you write npm init path \<path\>. This only exists because of historical reasons where mkdirp was not Promisifyed and no npx existed. Today this is not needed anymore. Today it only Protects the create-path namespace on npmjs with a usefull package wrapper.
+
+runs `npx mkdirp <path>` when you write `npm init path <path>`.
+**This only exists out of historical reasons** where mkdirp was not promisified and no npx existed.
+Today this is not needed anymore.
+It only protects the create-path namespace on npmjs with a useful package wrapper.
 
 A wrapper for mkdirp to also use it with npm init like:
 
@@ -7,10 +11,12 @@ A wrapper for mkdirp to also use it with npm init like:
 npm init path ~/myProject
 ```
 
-It is using npm:mkdirp under the hood and it is not usefull for anything else then using it with npm init in general you should always prefer
+It is using `npm:mkdirp` under the hood, and it is not useful for anything other than using it with `npm init`.
+Generally, you should always prefer
 
 ```
 npx mkdirp ~/myProject
 ```
 
-This only exists because of historical reasons where mkdirp was not Promisifyed and no npx existed. Today this is not needed anymore.
+This only exists because of historical reasons where mkdirp was not promisified and no npx existed. Today this is not
+needed anymore.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# create-path - promise version of mkdirp
+# create-path
+runs npx mkdirp \<path\> when you write npm init path \<path\>. This only exists because of historical reasons where mkdirp was not Promisifyed and no npx existed. Today this is not needed anymore. Today it only Protects the create-path namespace on npmjs with a usefull package wrapper.
 
 A wrapper for mkdirp to also use it with npm init like:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # create-path - promise version of mkdirp
 
-like mkdirp (see https://www.npmjs.com/package/mkdirp) without callbacks.
+A wrapper for mkdirp to also use it with npm init like:
+
+```
+npm init path ~/myProject
+```
+
+It is using npm:mkdirp under the hood and it is not usefull for anything else then using it with npm init in general you should always prefer
+
+```
+npx mkdirp ~/myProject
+```
+
+This only exists because of historical reasons where mkdirp was not Promisifyed and no npx existed. Today this is not needed anymore.

--- a/createPath.js
+++ b/createPath.js
@@ -1,15 +1,3 @@
 const mkdirp = require('mkdirp')
 
-module.exports = createPath;
-
-function createPath(dir, opts, cb) {
-  return new Promise((resolve, reject) => {
-    mkdirp(dir, opts, (err, made) => {
-      if(err) {
-        reject(err)
-      } else {
-        resolve(made)
-      }
-    })
-  })
-}
+module.exports = mkdirp;

--- a/createPathCli.js
+++ b/createPathCli.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('node:child_process').exec(`npx mkdirp ${process.argv.slice(1).join()}`, { stdio: "inhire"},
+(error, _stdout, _stderr) => (error) && console.error(`exec error: ${error}`));

--- a/createPathCli.js
+++ b/createPathCli.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-require('node:child_process').exec(`npx mkdirp ${process.argv.slice(1).join()}`, { stdio: "inhire"},
-(error, _stdout, _stderr) => (error) && console.error(`exec error: ${error}`));
+require('node:child_process').exec(`npx mkdirp ${process.argv.slice(2).join()}`, {stdio: "inhire"},
+    (error, _stdout, _stderr) => (error) && console.error(`exec error: ${error}`));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "create-path",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "promise version of mkdirp",
+  "bin": { "create-path": "createPathCli.js" },
   "main": "createPath.js",
   "scripts": {
     "test": "exit 0"
@@ -24,6 +25,6 @@
   },
   "homepage": "https://github.com/robojones/create-path#readme",
   "dependencies": {
-    "mkdirp": "^0.5.1"
+    "mkdirp": "npm:mkdirp@latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "create-path",
   "version": "2.0.1",
   "description": "promise version of mkdirp",
-  "bin": { "create-path": "createPathCli.js" },
+  "bin": {
+    "create-path": "createPathCli.js"
+  },
   "main": "createPath.js",
   "scripts": {
     "test": "exit 0"


### PR DESCRIPTION
I think this package is still usefull to protect the name create-path as it is a importent name space as it executes when you run npm init path <path> which does happen so i patched it to expose mkdirp directly to add real functionality to the package again 

please test review and publish if you do not got time for testing i will test it soon and comment